### PR TITLE
Use new TestContainers library directly

### DIFF
--- a/dotnet_3/em/embedded/rest/MenuAPIDriver/MenuAPIDriver.csproj
+++ b/dotnet_3/em/embedded/rest/MenuAPIDriver/MenuAPIDriver.csproj
@@ -9,10 +9,6 @@
   </PropertyGroup>
 	
 	<Import Project="../../../common.props" />
-	
-  <ItemGroup>
-    <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../../../cs/rest/Menu.API/Menu.API/Menu.API.csproj" />
@@ -37,6 +33,10 @@
 		<TempDirectory Include="$(ProjectDir)bin-temp" />
 		<InstrumentationRuntimeConfig Include="$(OutputPath)EvoMaster.Instrumentation.runtimeconfig.json" />
 	</ItemGroup>
+	
+	<ItemGroup>
+	  <PackageReference Include="TestContainers.postgresql" Version="3.1.0" />
+	</ItemGroup>
 
 	<Target Name="Instrument" AfterTargets="Build">
 
@@ -48,7 +48,8 @@
 		<Copy SourceFiles="@(CurrentRuntimeConfig)" DestinationFiles="@(InstrumentationRuntimeConfig)" />
 
 		<!-- Run the instrumentation and specify bin-temp as output directory -->
-		<Exec Command="cd $(OutputPath)&#xD;&#xA;		dotnet EvoMaster.Instrumentation.dll @(Sut) @(TempDirectory)" />
+		<Exec Command="cd $(OutputPath)
+		dotnet EvoMaster.Instrumentation.dll @(Sut) @(TempDirectory)" />
 
 	</Target>
 


### PR DESCRIPTION
There was a weird issue while trying to start the database container. To solve this, TestContainers is now being used directly inside menu-api driver, instead of using DataBaseController from EvoMaster which was based on Dotnet.TestContainers that is deprecated.